### PR TITLE
feat: support upload speed limit for per torrent

### DIFF
--- a/byre/bt.py
+++ b/byre/bt.py
@@ -25,6 +25,7 @@ import qbittorrentapi
 import byre.clients
 from byre import utils
 from byre.clients.data import LocalTorrent, TorrentInfo
+from byre.commands.config import GlobalConfig
 
 _logger = logging.getLogger("byre.bt")
 _debug, _info, _warning, _fatal = _logger.debug, _logger.info, _logger.warning, _logger.fatal
@@ -47,6 +48,11 @@ class BtClient:
         _debug("qBittorrent 信息：软件版本 %s，API 版本 %s", self.client.app.version, self.client.app.web_api_version)
         if self.client.app.version < "v4.5.2":
             raise ConnectionError("请升级到更新的 qBittorrent 版本")
+        #: 一些额外的配置（可通过 load_config 覆写）
+        self.upload_limit = 95.0
+
+    def load_config(self, config: GlobalConfig):
+        self.upload_limit = config.optional(float, 95.0, "qbittorrent", "upload_speed_limit")
 
     def init_webui(self, username: str, password: str):
         """设置 Web UI 的用户名和密码。"""
@@ -109,6 +115,7 @@ class BtClient:
             is_paused=paused,
             rename=title,
             tags=[info.site],
+            upload_limit=int(self.upload_limit * 1024 * 1024)
         )
 
     def rename_torrent(self, torrent: LocalTorrent, info: TorrentInfo) -> None:

--- a/byre/commands/bt.py
+++ b/byre/commands/bt.py
@@ -43,6 +43,7 @@ class BtCommand(ConfigurableGroup):
     @override
     def configure(self, config: GlobalConfig):
         self.api = BtClient(config.require(str, "qbittorrent", "url", password=True))
+        self.api.load_config(config)
         self.config = config
 
     @click.command

--- a/byre/setup/byre.example.toml
+++ b/byre/setup/byre.example.toml
@@ -50,6 +50,9 @@ url = "{qbt_url}"
 # 种子数据缓存
 cache_database = "{cache_db}"
 
+# 单种上传限速，单位是 MB/s
+upload_speed_limit = 95.0
+
 [planning.partition_0]
 # 实际可用空间的规划相关
 
@@ -72,6 +75,8 @@ download_dir = "{download_dir}"
 # max_total_size = "200 GiB"
 # max_download_size = "25 GiB"
 # download_dir = "/home/pi/MySmallerDisk2"
+# # 如果是 Windows 系统
+# download_dir = "F:\\TEST"
 
 # {extra_partitions}
 


### PR DESCRIPTION
**原因**
尝试支持了一下单种上传限速。BYR 的单种上传限速是 125MB/s，TJU 则是 100MB/s，为了防止超速，还是设置一下为好~

**已测试通过的环境**
+ Windows 10，Python 3.11.2
+ Debian 11，Python 3.9.2

**其它**
这次的修改方式是通过在 `BtClient` 中添加 `load_config` 方法，方便加载外部配置。主要是为便于以后参照 `qbittorrent-api` 库的 [文档](https://qbittorrent-api.readthedocs.io/en/latest/apidoc/torrents.html) 进行一些拓展，比如分享率限制，做种时间限制之类的。
