### PR TITLE
fix: Python 版本兼容性

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@
 
 ### 安装
 
+建议的 Python 版本：3.9 及以上 
+
 ```console
 $ git clone https://github.com/yesh0/byre.git
 $ pip3 install --use-pep517 ./byre

--- a/byre/utils.py
+++ b/byre/utils.py
@@ -19,6 +19,7 @@ import logging
 import re
 import typing
 from dataclasses import dataclass
+from typing import Optional
 
 import click
 
@@ -163,7 +164,7 @@ def cast(t: typing.Type[T], value: typing.Any) -> T:
     raise TypeError(f"类型错误：{type(value)} 无法转为 {t}")
 
 
-def not_none(value: T | None, msg: str | None = "值不能为 None") -> T:
+def not_none(value: Optional[T], msg: Optional[str] = "值不能为 None") -> T:
     """Inline None 值校验。"""
     if value is None:
         raise ValueError(msg)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "psutil>=5.9.4",
     "appdirs>=1.4.4",
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 readme = "README.md"
 license = {text = "AGPLv3"}
 


### PR DESCRIPTION
### 原因

近期在服务器上尝试 Pull 了一下最新版的代码，更新了一波 byre，但是发现运行却报错了。（Debian11，使用系统自带的 Python 3.9）

研究了一下，发现是新版中有了个 `not_none` 的函数，在函数声明中使用了管道符号 ` | ` 表示联合类型（Union Type），但这一特性仅被 Python 3.10 及更高版本中支持，所以报错。后续升级到 3.12 版本的 Python 后果然就解决了。

在服务器上装新版的 Python 需要自行编译，对小白用户来说不是很友好，也比较麻烦。

故做出一些修改，使用了旧版的联合类型写法。

### 其他

初步测试了一通，没有发现功能异常。

既然考虑到版本兼容性问题，干脆也试了一下 Python 3.8，遂寄。故在 doc 中添加了版本建议，建议使用 Python 3.9 及以上。